### PR TITLE
Added following changes:

### DIFF
--- a/charts/sfapm-python3/templates/72-esmanager-deployment.yaml
+++ b/charts/sfapm-python3/templates/72-esmanager-deployment.yaml
@@ -130,16 +130,16 @@ spec:
               containerPort: 8000
               protocol: TCP
           livenessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 15
+            initialDelaySeconds: 60
+            periodSeconds: 300
+            timeoutSeconds: 65
             httpGet:
               path: /es-manager/health/
               port: http
           readinessProbe:
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            timeoutSeconds: 15
+            initialDelaySeconds: 60
+            periodSeconds: 300
+            timeoutSeconds: 65
             httpGet:
               path: /es-manager/health/
               port: http


### PR DESCRIPTION
issue:
1. ES manager pods restarting many times

cause:
1 due to liveiness probe failure, The esmanager is not responding within 10s for few calls that involves
  multiple datasources.

fix made:
1. Increased esmanager pods timeout seconds to 65 seconds.