### PR TITLE
Added helm chart of db-sfpoller

### DIFF
--- a/charts/db-sfpoller/Chart.yaml
+++ b/charts/db-sfpoller/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: db-sfpoller
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/db-sfpoller/templates/_helpers.tpl
+++ b/charts/db-sfpoller/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "db-sfpoller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "db-sfpoller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "db-sfpoller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "db-sfpoller.labels" -}}
+helm.sh/chart: {{ include "db-sfpoller.chart" . }}
+{{ include "db-sfpoller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "db-sfpoller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "db-sfpoller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "db-sfpoller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "db-sfpoller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/db-sfpoller/templates/configmap.yaml
+++ b/charts/db-sfpoller/templates/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+data:
+  config.yaml: |-
+    key: {{ .Values.profile_key }}
+    metrics:
+        plugins:
+        - name: postgres
+          enabled: true
+          interval: 30
+          config:
+            documentsTypes:
+              - databaseDetails
+              - indexDetails
+              - queryDetails
+              - serverDetails
+              - tableDetails
+            server_details:
+              {{-  range  $val := .Values.postgres_server_details }}
+              - host:{{ $val.host }}
+                user:{{ $val.user }}
+                port:{{ $val.port }}
+                password :{{ $val.password | b64enc }}
+              {{- end }}
+
+        - name: mysql
+          enabled: true
+          interval: 30
+          config:
+            documentsTypes:
+              - databaseDetails
+              - indexDetails
+              - queryDetails
+              - serverDetails
+              - tableDetails
+            server_details:
+              {{-  range  $val := .Values.mysql_server_details }}
+              - host:{{ $val.host }}
+                user:{{ $val.user }}
+                port:{{ $val.port }}
+                password :{{ $val.password | b64enc }}
+              {{- end }}
+
+kind: ConfigMap
+metadata:
+  name: sfpoller-configmap
+

--- a/charts/db-sfpoller/templates/pod.yaml
+++ b/charts/db-sfpoller/templates/pod.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sfkubeagent
+  labels:
+    snappyflow/appname: {{  .Values.app_name }}
+    snappyflow/projectname: {{ .Values.project_name }}
+spec:
+  containers:
+  - command:
+    - /app/sfagent
+    - -config-file
+    - /opt/sfagent/config.yaml
+    - -enable-console-log
+    env:
+    - name: APP_NAME
+      value: {{ .Values.app_name }}
+    - name: PROJECT_NAME
+      value: {{ .Values.project_name }}
+    image: snappyflowml/sfagent:latest
+    resources:
+      limits:
+        cpu: {{ .Values.container_cpu_limit }}
+        memory: {{ .Values.container_memory_limit }}
+    name: sfagent-container
+    volumeMounts:
+    - mountPath: /opt/sfagent/config.yaml
+      name: configmap-sfkubeagent
+      subPath: config.yaml
+  volumes:
+  - configMap:
+      defaultMode: 420
+      name: sfpoller-configmap
+    name: configmap-sfkubeagent 

--- a/charts/db-sfpoller/values.yaml
+++ b/charts/db-sfpoller/values.yaml
@@ -1,0 +1,21 @@
+project_name: <project_name>
+
+app_name: <app_name>
+
+profile_key: <profile_key>
+
+container_cpu_limit: 500m
+
+container_memory_limit: 500Mi
+
+postgres_server_details:
+- host: <host>
+  port: <port>
+  user: <user>
+  password: <password>
+
+mysql_server_details:
+- host: <host>
+  port: <port>
+  user: <user>
+  password: <password>


### PR DESCRIPTION
Added Helm Chart db-sfpoller.
This can be  used to monitor remote postgres and mysql endpoints like RDS, Azure database.