### PR TITLE
Modified configmap on db-sfpoller from list to map for server_details

### DIFF
--- a/charts/db-sfpoller/Chart.yaml
+++ b/charts/db-sfpoller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/db-sfpoller/templates/configmap.yaml
+++ b/charts/db-sfpoller/templates/configmap.yaml
@@ -16,10 +16,10 @@ data:
               - tableDetails
             server_details:
               {{-  range  $val := .Values.postgres_server_details }}
-              - host:{{ $val.host }}
-                user:{{ $val.user }}
-                port:{{ $val.port }}
-                password :{{ $val.password | b64enc }}
+              - host: {{ $val.host }}
+                user: {{ $val.user }}
+                port: {{ $val.port }}
+                password: {{ $val.password | b64enc }}
               {{- end }}
 
         - name: mysql
@@ -34,10 +34,10 @@ data:
               - tableDetails
             server_details:
               {{-  range  $val := .Values.mysql_server_details }}
-              - host:{{ $val.host }}
-                user:{{ $val.user }}
-                port:{{ $val.port }}
-                password :{{ $val.password | b64enc }}
+              - host: {{ $val.host }}
+                user: {{ $val.user }}
+                port: {{ $val.port }}
+                password: {{ $val.password | b64enc }}
               {{- end }}
 
 kind: ConfigMap


### PR DESCRIPTION
Issues: 
Helm chart takes server details as list and expected is map.
Changes:
Type of server_details in configmap is changed from list to map. Space is added after colon to make it as map
Test cases:
Tested helm chart installation on kubernetes cluster.