### PR TITLE
Add: compaction_arn added to spark-manager

### DIFF
--- a/charts/sf-archival/charts/spark-manager/templates/configmap.yaml
+++ b/charts/sf-archival/charts/spark-manager/templates/configmap.yaml
@@ -170,7 +170,7 @@ data:
             "task_subnet": "{{ .Values.infrastructure.EcsFargate.taskSubnet }}",
             "task_security_group": "{{ .Values.infrastructure.EcsFargate.taskSecurityGroup }}",
             "task_image": "{{ .Values.compactionImage }}",
-            "compaction_arn": "{{ .Values.infrastructure.EcsFargate.compactionArn }}"
+            "compaction_secret_arn": "{{ .Values.infrastructure.EcsFargate.compactionSecretArn }}"
           }
         }
 {{- end }}

--- a/charts/sf-archival/charts/spark-manager/templates/configmap.yaml
+++ b/charts/sf-archival/charts/spark-manager/templates/configmap.yaml
@@ -169,7 +169,8 @@ data:
             },
             "task_subnet": "{{ .Values.infrastructure.EcsFargate.taskSubnet }}",
             "task_security_group": "{{ .Values.infrastructure.EcsFargate.taskSecurityGroup }}",
-            "task_image": "{{ .Values.compactionImage }}"
+            "task_image": "{{ .Values.compactionImage }}",
+            "compaction_arn": "{{ .Values.infrastructure.EcsFargate.compactionArn }}"
           }
         }
 {{- end }}

--- a/charts/sf-archival/values.yaml
+++ b/charts/sf-archival/values.yaml
@@ -119,6 +119,7 @@ spark-manager:
       iamRole: arn:aws:iam::159750416379:role/Dev-Archival-presto_hive
       taskSubnet: subnet-09a6fcdc2b614e300
       taskSecurityGroup: sg-03b8db147f1b7b423
+      compactionArn: arn:aws:secretsmanager:XXX:XXX:secret:XXX
       jobResources:
         cpu: 2048
         memory: 8192

--- a/charts/sf-archival/values.yaml
+++ b/charts/sf-archival/values.yaml
@@ -119,7 +119,7 @@ spark-manager:
       iamRole: arn:aws:iam::159750416379:role/Dev-Archival-presto_hive
       taskSubnet: subnet-09a6fcdc2b614e300
       taskSecurityGroup: sg-03b8db147f1b7b423
-      compactionArn: arn:aws:secretsmanager:XXX:XXX:secret:XXX
+      compactionSecretArn: arn:aws:secretsmanager:XXX:XXX:secret:XXX
       jobResources:
         cpu: 2048
         memory: 8192


### PR DESCRIPTION
Feature: - compaction_secret_arn added to spark-manager

Analysis: - For task to pull private images, it need Repository credentials which contains secret manager ARN, which has username and password of docker. This should be passed to specific go file through this config map.

Jira Ticket: - https://maplelabs.atlassian.net/browse/SNP-5844

Test Cases:- Verified the path of helm yaml and added specific set operation for compactionSecretArn in CF template helm install command.