### PR TITLE
IMS-4

### DIFF
--- a/charts/sfapm-python3/templates/72-esmanager-deployment.yaml
+++ b/charts/sfapm-python3/templates/72-esmanager-deployment.yaml
@@ -129,20 +129,20 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-          livenessProbe:
-            initialDelaySeconds: 60
-            periodSeconds: 300
-            timeoutSeconds: 65
-            httpGet:
-              path: /es-manager/health/
-              port: http
-          readinessProbe:
-            initialDelaySeconds: 60
-            periodSeconds: 300
-            timeoutSeconds: 65
-            httpGet:
-              path: /es-manager/health/
-              port: http
+#           livenessProbe:
+#             initialDelaySeconds: 60
+#             periodSeconds: 300
+#             timeoutSeconds: 65
+#             httpGet:
+#               path: /es-manager/health/
+#               port: http
+#           readinessProbe:
+#             initialDelaySeconds: 60
+#             periodSeconds: 300
+#             timeoutSeconds: 65
+#             httpGet:
+#               path: /es-manager/health/
+#               port: http
           resources:
             {{- toYaml .Values.esmanager.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Commented out liveness and readiness check in order to debug https://maplelabs.atlassian.net/browse/IMS-4 Since we don't have es-manager pod logs coming in, it's hard to predict why probe is failing. So the plan is to comment out the probes and trigger the health call as a cron with a longer timeout to determine which part of health check is failing