### PR TITLE
Update: Trace server memory limit

### DIFF
--- a/charts/sfapm-python3/values.yaml
+++ b/charts/sfapm-python3/values.yaml
@@ -495,7 +495,7 @@ sftrace:
       memory: 50Mi
     limits:
       cpu: 1
-      memory: 512Mi
+      memory: 1024Mi
 
   service:
     type: NodePort


### PR DESCRIPTION
Analysis:
For some deployments, we observed that trace pods were getting killed due OutOfMemory issue.

Fix:
Updated trace pod max memory limit