### PR TITLE
Update: apm-server.yml config with optimal kafka settings

### DIFF
--- a/charts/sfapm-python3/templates/40-sftrace-configmap.yaml
+++ b/charts/sfapm-python3/templates/40-sftrace-configmap.yaml
@@ -17,16 +17,26 @@ data:
           host: 0.0.0.0:14268
     queue:
       mem:
-        events: 16384
+        events: 65536
+        flush.min_events: 0
+        flush.timeout: 0s
     {{- if .Values.sftrace.output.kafka.enabled }}
     output.kafka:
       enabled: true
       hosts: {{ .Values.sftrace.output.kafka.hosts | toJson }}
       topic: beats
-      worker: 1
-      channel_buffer_size: 16384
-      bulk_max_size: 2048
+      worker: 5
+      timeout: 5
+      channel_buffer_size: 5000
+      bulk_max_size: 5000
       compression: "snappy"
+      partition.random:
+        group_events: 1000
+        reachable_only: true
+      bulk_flush_frequency: 2s
+      keep_alive: 300s
+      max_message_bytes: 10000000
+      required_acks: 1
     {{- else }}
     output.kafkarest:
       enabled: true


### PR DESCRIPTION
**Analysis:**
We were facing "queue full error" due to high tracing data ingestion rate.

**Fix:**
Updated apm-server.yml with suggested kafka config to handle the load.


**Test Case:**
Sent high ingestion data to trace server to check queue full error.

**Result:**
No "queue full error" is seen at the trace server side.