### PR TITLE
Fix: Configmap is added to es manager to support account access key

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.336
+version: 4.0.337
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/templates/10-sfapm-configmap.yaml
+++ b/charts/sfapm-python3/templates/10-sfapm-configmap.yaml
@@ -51,10 +51,6 @@ data:
     {{- else }}
     KEYCLOAK_MODE: ""
     {{- end }}
-    {{- if eq "azure" .Values.sfapm.cloud }}
-    STORAGE_ACCOUNT_NAME: "{{ .Values.sfapm.azure.storage_account_name }}"
-    STORAGE_ACCOUNT_KEY: "{{ .Values.sfapm.azure.storage_account_key }}"
-    {{- end }}
     {{- if .Values.sfapm.rollover.custom_config }}
     METRIC_ROLLOVER_MAX_AGE: "{{ .Values.sfapm.rollover.metric.rollover_max_age }}"
     METRIC_ROLLOVER_MAX_DOCS: "{{ .Values.sfapm.rollover.metric.rollover_max_docs }}"

--- a/charts/sfapm-python3/templates/70-esmanager-configmap.yaml
+++ b/charts/sfapm-python3/templates/70-esmanager-configmap.yaml
@@ -22,6 +22,11 @@ data:
     DB_PASSWORD: {{ .Values.postgresql.external.dbPassword }}
     {{- end }}
 
+    {{- if eq "azure" .Values.sfapm.cloud }}
+    STORAGE_ACCOUNT_NAME: "{{ .Values.sfapm.azure.storage_account_name }}"
+    STORAGE_ACCOUNT_KEY: "{{ .Values.sfapm.azure.storage_account_key }}"
+    {{- end }}
+    
     REDIS_HOST: {{ .Release.Name  }}-redis
     REDIS_PORT: "6379"
 


### PR DESCRIPTION
Fix: Configmap is added to es manager to support account access key

Analysis: This configmap is used for creating metrics backup in storage account

Testcase: Verfied in stage, able to create cm in esmanager service