### PR TITLE
Fix: nginx ingress is configured to aws external loadbalancer

### DIFF
--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-ingress
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.6.22
+version: 3.6.23
 appVersion: 1.5.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -6,6 +6,9 @@ metadata:
   {{- range $key, $value := .Values.controller.service.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
+  {{- if .Values.global.subnets }}
+    {{ toYaml .Values.controller.service.externalLoadbalancerAnnotation | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -15,6 +15,7 @@ global:
   snappyflowAppLabel: "snappyflow/appname"
   snappyflowProjectName: "snappyflow-app"
   snappyflowAppName: "sf-data-path"
+  subnets: ""
 commonLabels: {}
 # scmhash: abc123
 # myLabel: aakkmd
@@ -482,6 +483,11 @@ controller:
     appProtocol: true
 
     annotations: {}
+    externalLoadbalancerAnnotation:
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "80,443,8443"
+      service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '3600'
     labels: {}
     # clusterIP: ""
 


### PR DESCRIPTION
Fix: nginx ingress is configured to aws external loadbalancer

Testcase: Verified by deploying helm chart in aws env, able to create it successfully