### PR TITLE
Fix: nginx ingress controller is configured with proxy body size 13m

### DIFF
--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-ingress
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.6.23
+version: 3.6.24
 appVersion: 1.5.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -13,6 +13,7 @@ metadata:
   name: {{ include "ingress-nginx.controller.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
+  proxy-body-size: "13m"
   allow-snippet-annotations: "{{ .Values.controller.allowSnippetAnnotations }}"
 {{- if .Values.controller.addHeaders }}
   add-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-add-headers


### PR DESCRIPTION
Fix: nginx ingress controller is configured with proxy body size 13m

Analysis: New nginx chart is not configured with proxy body size, currently, i have added this changes.