### PR TITLE
Fix: label is added to ingress deployment and updated ingress rule only to azure

### DIFF
--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-ingress
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.6.24
+version: 3.6.25
 appVersion: 1.5.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -41,6 +41,8 @@ spec:
     {{- end }}
       labels:
         {{- include "ingress-nginx.selectorLabels" . | nindent 8 }}
+        {{ .Values.global.snappyflowProjectLabel}}: {{ .Values.global.snappyflowProjectName }}
+        {{ .Values.global.snappyflowAppLabel }}: {{ .Values.global.snappyflowAppName }}
         app.kubernetes.io/component: controller
         {{- with .Values.controller.labels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -7,6 +7,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   {{- if .Values.global.subnets }}
+    service.beta.kubernetes.io/aws-load-balancer-subnets: {{ .Values.global.subnets | replace " " "," }}
     {{ toYaml .Values.controller.service.externalLoadbalancerAnnotation | nindent 4 }}
   {{- end }}
   labels:
@@ -68,7 +69,11 @@ spec:
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
+      {{- if .Values.global.subnets }}
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      {{- else }}
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+      {{- end }}
     {{- if and (semverCompare ">=1.20" .Capabilities.KubeVersion.Version) (.Values.controller.service.appProtocol) }}
       appProtocol: https
     {{- end }}

--- a/charts/nginx-ingress/templates/controller-suspected-client-blocking.yaml
+++ b/charts/nginx-ingress/templates/controller-suspected-client-blocking.yaml
@@ -3,12 +3,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    {{- include "nginx-ingress.labels" . | nindent 4 }}
+    {{- include "ingress-nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
 {{- if .Values.controller.configAnnotations }}
   annotations: {{ toYaml .Values.controller.configAnnotations | nindent 4 }}
 {{- end }}
-  name: {{ include "nginx-ingress.fullname" . }}-suspected-client-block
+  name: {{ include "ingress-nginx.fullname" . }}-suspected-client-block
 data:
   config.yaml: |+
     ---

--- a/charts/nginx-ingress/templates/ingress-rule.yaml
+++ b/charts/nginx-ingress/templates/ingress-rule.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.subnets }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -18,4 +19,4 @@ spec:
             port: 
               number: 80
         pathType: Prefix
-
+{{- end }}


### PR DESCRIPTION
Fix: label is added to ingress deployment and updated ingress rule only to azure

Analysis: AWS is enabled with targetpor http and label is missing

Testcase: Deployed in AWS stage, able to access UI without any issue.