### PR TITLE
enable kubernetes mode for compaction

### DIFF
--- a/charts/sf-archival/charts/spark-manager/templates/configmap.yaml
+++ b/charts/sf-archival/charts/spark-manager/templates/configmap.yaml
@@ -104,6 +104,8 @@ data:
               "spark.kubernetes.executor.label.release={{ .Release.Name }}",
               "--conf",
               "spark.kubernetes.container.image={{ .Values.compactionImage }}",
+              "--conf",
+              "spark.kubernetes.container.image.pullSecrets={{ .Values.global.imagePullSecrets }}",
 {{- if or (and (eq .Values.global.secrets.aws.enable true) (eq .Values.global.secrets.aws.use_iam_role true)) (and (eq .Values.global.secrets.gcs.enable true) (eq .Values.global.secrets.gcs.use_google_service_account true)) }}
               "--conf",
               "spark.kubernetes.authenticate.driver.serviceAccountName={{ .Release.Name }}-service-account",

--- a/charts/sf-archival/values.yaml
+++ b/charts/sf-archival/values.yaml
@@ -98,9 +98,8 @@ spark-manager:
       logDirectory: sparkhs/spark-hs
   infrastructure:
     Kubernetes:
-      # Kubernetes is always inserted as an infrastructure with slightly higher preference numbers
-      # If some other infrastructure has higher preference, that infrastructure will be used
-      preference: 10
+      # Kubernetes infrastructure is used by default
+      preference: 1
       numExecutors: 5
       jobResources:
         cpu:
@@ -114,9 +113,11 @@ spark-manager:
           executor: 1024m
           driver: 1024m
     EcsFargate:
+      # EcsFargate is inserted as an infrastructure with slightly higher preference number
+      # EcsFargate is disabled by default
       enabled: false
       containerInsightsEnabled: false
-      preference: 1
+      preference: 10
       cluster: sf-archival-compaction
       numExecutors: 2
       iamRole: arn:aws:iam::159750416379:role/Dev-Archival-presto_hive


### PR DESCRIPTION
Added a lesser preference number for Kubernetes mode and a higher preference number for the ECSFargate mode so that Kubernetes mode will be picked up by default.
Also added a config for the secret to be used for pulling the private snappyflowml compaction image.