### PR TITLE
kafka broker Monitoring Issue SNP-6675

### DIFF
--- a/charts/kafka-cluster/charts/cp-kafka/README.md
+++ b/charts/kafka-cluster/charts/cp-kafka/README.md
@@ -174,8 +174,8 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
-| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `bitnami/jmx-exporter@sha256` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/kafka-cluster/charts/cp-kafka/values.yaml
+++ b/charts/kafka-cluster/charts/cp-kafka/values.yaml
@@ -12,8 +12,8 @@ prometheus:
 
   jmx:
     enabled: true
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    image: bitnami/jmx-exporter@sha256
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     imagePullPolicy: IfNotPresent
     port: 5556
 

--- a/charts/kafka-cluster/charts/cp-zookeeper/README.md
+++ b/charts/kafka-cluster/charts/cp-zookeeper/README.md
@@ -181,8 +181,8 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
-| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `bitnami/jmx-exporter@sha256` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/kafka-cluster/charts/cp-zookeeper/values.yaml
+++ b/charts/kafka-cluster/charts/cp-zookeeper/values.yaml
@@ -120,8 +120,8 @@ prometheus:
   ## ref: https://github.com/prometheus/jmx_exporter
   jmx:
     enabled: true
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    image: bitnami/jmx-exporter@sha256
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     imagePullPolicy: IfNotPresent
     port: 5556
 

--- a/charts/kafka/charts/zookeeper/values.yaml
+++ b/charts/kafka/charts/zookeeper/values.yaml
@@ -85,10 +85,10 @@ prometheus:
     enabled: true
 
     ## The image to use for the metrics collector
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    image: bitnami/jmx-exporter@sha256
 
     ## The image tag to use for the metrics collector
-    imageTag: a23062396cd5af1acdf76512632c20ea6be76885dfc20cd9ff40fb23846557e8
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
 
     ## Interval at which Prometheus scrapes metrics, note: only used by Prometheus Operator
     interval: 10s

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -235,10 +235,10 @@ prometheus:
     enabled: true
 
     ## The image to use for the metrics collector
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    image: bitnami/jmx-exporter@sha256
 
     ## The image tag to use for the metrics collector
-    imageTag: a23062396cd5af1acdf76512632c20ea6be76885dfc20cd9ff40fb23846557e8
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
 
     ## Interval at which Prometheus scrapes metrics, note: only used by Prometheus Operator
     interval: 10s

--- a/charts/sf-datapath/sub_charts/autoscaling/sub_charts/prometheus/values.yaml
+++ b/charts/sf-datapath/sub_charts/autoscaling/sub_charts/prometheus/values.yaml
@@ -144,13 +144,13 @@ server:
   global:
     ## How frequently to scrape targets by default
     ##
-    scrape_interval: 5s
+    scrape_interval: 60s
     ## How long until a scrape request times out
     ##
-    scrape_timeout: 3s
+    scrape_timeout: 45s
     ## How frequently to evaluate rules
     ##
-    evaluation_interval: 5s
+    evaluation_interval: 60s
     query_log_file: /prometheus/query.log
   ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
   ##

--- a/charts/sf-datapath/sub_charts/azureblob-kafka-connect/README.md
+++ b/charts/sf-datapath/sub_charts/azureblob-kafka-connect/README.md
@@ -142,8 +142,8 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
-| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `bitnami/jmx-exporter@sha256` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/sf-datapath/sub_charts/azureblob-kafka-connect/values.yaml
+++ b/charts/sf-datapath/sub_charts/azureblob-kafka-connect/values.yaml
@@ -55,9 +55,9 @@ podAnnotations: {}
 prometheus:
   jmx:
     enabled: true
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    image: bitnami/jmx-exporter@sha256
     imagePullPolicy: IfNotPresent
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     port: 5556
 replicaCount: 1
 terminationGracePeriodSeconds: 200

--- a/charts/sf-datapath/sub_charts/cp-kafka-rest/README.md
+++ b/charts/sf-datapath/sub_charts/cp-kafka-rest/README.md
@@ -146,8 +146,8 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
-| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `bitnami/jmx-exporter@sha256` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/sf-datapath/sub_charts/cp-kafka-rest/values.yaml
+++ b/charts/sf-datapath/sub_charts/cp-kafka-rest/values.yaml
@@ -59,9 +59,9 @@ podAnnotations: {}
 prometheus:
   jmx:
     enabled: true
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    image: bitnami/jmx-exporter@sha256
     imagePullPolicy: IfNotPresent
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     port: 5556
 replicaCount: 1
 servicePort: 8082

--- a/charts/sf-datapath/sub_charts/cp-schema-registry/README.md
+++ b/charts/sf-datapath/sub_charts/cp-schema-registry/README.md
@@ -151,7 +151,7 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
 | `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/sf-datapath/sub_charts/cp-schema-registry/values.yaml
+++ b/charts/sf-datapath/sub_charts/cp-schema-registry/values.yaml
@@ -45,9 +45,9 @@ podAnnotations: {}
 prometheus:
   jmx:
     enabled: false
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    image: bitnami/jmx-exporter@sha256
     imagePullPolicy: IfNotPresent
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     port: 5556
 replicaCount: 1
 schemaGenerator:

--- a/charts/sf-datapath/sub_charts/es-kafka-connect/README.md
+++ b/charts/sf-datapath/sub_charts/es-kafka-connect/README.md
@@ -143,7 +143,7 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
 | `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/sf-datapath/sub_charts/es-kafka-connect/values.yaml
+++ b/charts/sf-datapath/sub_charts/es-kafka-connect/values.yaml
@@ -63,9 +63,9 @@ podAnnotations: {}
 prometheus:
   jmx:
     enabled: true
-    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    image: bitnami/jmx-exporter@sha256
     imagePullPolicy: IfNotPresent
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     port: 5556
     resources: {}
 replicaCount: 1

--- a/charts/sf-datapath/sub_charts/s3-kafka-connect/README.md
+++ b/charts/sf-datapath/sub_charts/s3-kafka-connect/README.md
@@ -143,7 +143,7 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
 | `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811` |
 | `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |

--- a/charts/sf-datapath/sub_charts/s3-kafka-connect/values.yaml
+++ b/charts/sf-datapath/sub_charts/s3-kafka-connect/values.yaml
@@ -57,7 +57,7 @@ prometheus:
     enabled: true
     image: solsson/kafka-prometheus-jmx-exporter@sha256
     imagePullPolicy: IfNotPresent
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 2b03ed611421c0b58dcd70270fed9209c95a5b72a3f8bab186c2dcf27f974811
     port: 5556
 replicaCount: 1
 terminationGracePeriodSeconds: 200

--- a/charts/sf-datapath/values.yaml
+++ b/charts/sf-datapath/values.yaml
@@ -114,9 +114,9 @@ autoscaling:
     maxReplicas: 10
   prometheus:
     global:
-      scrape_interval: 5s
-      scrape_timeout: 3s
-      evaluation_interval: 5s
+      scrape_interval: 60s
+      scrape_timeout: 45s
+      evaluation_interval: 60s
       query_log_file: /prometheus/query.log
   prometheus-adapter:
     rules:


### PR DESCRIPTION
Issue: unable to get kafka broker pods heart beat and metrics in apm manger
Error:  kube-node/prom_metrics.go:198   failed to get response from endpoint {10.0.2.158 5556 metrics}, Get "[http://10.0.2.158:5556/metrics":](https://ind01.safelinks.protection.outlook.com/?url=http%3A%2F%2F10.0.2.158%3A5556%2Fmetrics%2522%3A&data=05%7C01%7CPothula.Kalyani%40Maplelabs.com%7C21fc0981f9a24dff3b8208daf51f07db%7C9b1bd430db96472688f5e0d3148d570d%7C0%7C0%7C638091810866190444%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=7e47W3UR%2Brm2J5uY113bkWievUmPnz7CRRxqBOQvx9w%3D&reserved=0) context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Fix : changing  evaluation_interval ,scrape_interval Scrape_timeout in Prometheus server
Before change: evaluation_interval : 5s
                         scrape_interval : 5s
                         Scrape_timeout :4s
After change: evaluation_interval : 60s
                      scrape_interval : 60s
                       Scrape_timeout :45s
Result: kafka service is being discovered and we are able to metrics in the APM Manager