### PR TITLE
changes for azure

### DIFF
--- a/charts/sf-archival/Chart.yaml
+++ b/charts/sf-archival/Chart.yaml
@@ -11,4 +11,4 @@ dependencies:
   version: 1.4.5
 description: A Helm chart for Kubernetes
 name: sf-archival
-version: 2.0.58
+version: 2.0.59

--- a/charts/sf-archival/templates/list-eks-nodes.yaml
+++ b/charts/sf-archival/templates/list-eks-nodes.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}-list-eks-nodes
@@ -9,7 +9,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-list-eks-nodes-binding

--- a/charts/spark-history-server/Chart.yaml
+++ b/charts/spark-history-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: spark-history-server
-version: 1.4.5
+version: 1.4.6
 appVersion: 2.4.0
 description: DEPRECATED - A Helm chart for Spark History Server
 home: https://spark.apache.org

--- a/charts/spark-history-server/templates/deployment.yaml
+++ b/charts/spark-history-server/templates/deployment.yaml
@@ -103,10 +103,6 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
-        {{- else if .Values.wasbs.enableWASBS }}
-        volumeMounts:
-        - name: secrets-volume
-          mountPath: /etc/secrets
         {{- else if .Values.hdfs.enableHDFS }}
         volumeMounts:
         - name: core-site
@@ -121,11 +117,6 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.pvc.existingClaimName }}
-      {{- else if .Values.wasbs.enableWASBS }}
-      volumes:
-      - name: secrets-volume
-        secret:
-          secretName: {{ .Values.wasbs.secret }}
       {{- else if .Values.hdfs.enableHDFS }}
       volumes:
       - name: hdfs-site


### PR DESCRIPTION
changes made:

- kubernetes server version on aws stage is 1.21 whereas on azure stage it is 1.23.
   So, as the apiVersion "rbac.authorization.k8s.io/v1beta1" is not supported on azure setup, changed it to "rbac.authorization.k8s.io/v1".

- removed volume mount for secrets when wasbs is enabled.