### PR TITLE
Remove Running driver as scaling parameter

### DIFF
--- a/charts/sf-presto/Chart.yaml
+++ b/charts/sf-presto/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sf-presto
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.12
+version: 1.0.13
 appVersion: "1.0.0"

--- a/charts/sf-presto/templates/presto-hpa.yaml
+++ b/charts/sf-presto/templates/presto-hpa.yaml
@@ -27,13 +27,6 @@ spec:
   - type: Pods
     pods:
       metric:
-        name: presto_running_drivers
-      target:
-        type: AverageValue
-        averageValue: {{ .Values.autoscaling.targetRunningDrivers }}
-  - type: Pods
-    pods:
-      metric:
         name: presto_queued_queries
       target:
         type: AverageValue


### PR DESCRIPTION
Remove Running driver as scaling parameter due to inconsistent behavior of number of drivers and workers are scaling more than expected.