### PR TITLE
pgbouncer: add db-specific configuration

### DIFF
--- a/charts/pgbouncer/templates/configmap.yaml
+++ b/charts/pgbouncer/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{ define "pgbouncer.ini.1.0.0" }}
 [databases]
 {{- range $k, $v := .Values.databases }}
-{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.dbname }}dbname={{ $v.dbname }}{{end}} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.password }}password={{ $v.password }}{{end}}
+{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.dbname }}dbname={{ $v.dbname }}{{end}} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.password }}password={{ $v.password }}{{end}} {{ if hasKey $.Values.connConfig $k }}{{ $val := get $.Values.connConfig $k }}{{ if $val.poolSize }}pool_size={{ $val.poolSize }}{{end}} {{ if $val.maxDBConnections }}max_db_connections={{ $val.maxDBConnections }}{{end}}{{end}}
 {{- end }}
 [pgbouncer]
 listen_addr = 0.0.0.0
@@ -11,9 +11,9 @@ auth_file = /etc/pgbouncer/userlist.txt
 {{- $users := (join "," (keys .Values.users | sortAlpha)) }}
 admin_users = {{ $users }}
 stats_users = {{ $users }},stats
-pool_mode = {{ .Values.connConfig.poolMode }}
-default_pool_size = {{ .Values.connConfig.defaultPoolSize }}
-max_db_connections = {{ .Values.connConfig.maxDBConnections }}
+pool_mode = {{ .Values.connConfig.default.poolMode }}
+default_pool_size = {{ .Values.connConfig.default.defaultPoolSize }}
+max_db_connections = {{ .Values.connConfig.default.maxDBConnections }}
 
 # extra config
 {{- range $k, $v := .Values.extraConfig }}

--- a/charts/pgbouncer/templates/configmap.yaml
+++ b/charts/pgbouncer/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{ define "pgbouncer.ini.1.0.0" }}
 [databases]
 {{- range $k, $v := .Values.databases }}
-{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.dbname }}dbname={{ $v.dbname }}{{end}} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.password }}password={{ $v.password }}{{end}} {{ if hasKey $.Values.connConfig $k }}{{ $val := get $.Values.connConfig $k }}{{ if $val.poolSize }}pool_size={{ $val.poolSize }}{{end}} {{ if $val.maxDBConnections }}max_db_connections={{ $val.maxDBConnections }}{{end}}{{end}}
+{{ $k }} = host={{ $v.host }} port={{ $v.port }} {{ if $v.dbname }}dbname={{ $v.dbname }}{{end}} {{ if $v.user }}user={{ $v.user }}{{end}} {{ if $v.password }}password={{ $v.password }}{{end}} {{ if hasKey $.Values.connConfig $k }}{{ $val := get $.Values.connConfig $k }}{{ if $val.numOfConnections }}pool_size={{ $val.numOfConnections }} max_db_connections={{ $val.numOfConnections }}{{end}}{{end}}
 {{- end }}
 [pgbouncer]
 listen_addr = 0.0.0.0
@@ -12,8 +12,8 @@ auth_file = /etc/pgbouncer/userlist.txt
 admin_users = {{ $users }}
 stats_users = {{ $users }},stats
 pool_mode = {{ .Values.connConfig.default.poolMode }}
-default_pool_size = {{ .Values.connConfig.default.defaultPoolSize }}
-max_db_connections = {{ .Values.connConfig.default.maxDBConnections }}
+default_pool_size = {{ .Values.connConfig.default.numOfConnections }}
+max_db_connections = {{ .Values.connConfig.default.numOfConnections }}
 
 # extra config
 {{- range $k, $v := .Values.extraConfig }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -96,12 +96,12 @@ connConfig:
   # default configurations go under the [pgbouncer] section as default values
   default:
     poolMode: transaction
-    defaultPoolSize: 20
-    maxDBConnections: 50
+    numOfConnections: 20
   # following db configurations go under the [databases] section as database-specific values
   # vizbuilder:
-  #   poolSize: 30
-  #   maxDBConnections: 40
+  #   numOfConnections: 40
+  # snappyflow:
+  #   numOfConnections: 30
 
 extraConfig:
   log_connections: 1

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -93,9 +93,15 @@ connConfig:
   #   session      - after client disconnects (default)
   #   transaction  - after transaction finishes
   #   statement    - after statement finishes
-  poolMode: transaction
-  defaultPoolSize: 20
-  maxDBConnections: 50
+  # default configurations go under the [pgbouncer] section as default values
+  default:
+    poolMode: transaction
+    defaultPoolSize: 20
+    maxDBConnections: 50
+  # following db configurations go under the [databases] section as database-specific values
+  # vizbuilder:
+  #   poolSize: 30
+  #   maxDBConnections: 40
 
 extraConfig:
   log_connections: 1


### PR DESCRIPTION
Changes:
- Configuration earlier was common for all the databases mentioned under the [databases] section.
- Changes are now made to use DB-specific configurations.
- These configurations will come under the [databases] section.
- The new configuration will look something like this:
   **[databases]
    snappyflow = host=pg-postgresql port=5432 dbname=snappyflow user=test password=test123 pool_size=30 max_db_connections=30
    vizbuilder = host=pg-postgresql port=5432 dbname=vizbuilder user=test password=test123 pool_size=40 max_db_connections=40
    [pgbouncer]
    listen_addr = 0.0.0.0
    listen_port = 6432
    auth_type = plain
    auth_file = /etc/pgbouncer/userlist.txt
    admin_users =
    stats_users = ,stats
    pool_mode = transaction
    default_pool_size = 20
    max_db_connections = 20**
- if DB-specific configurations are not mentioned, the default ones (specified under the [pgbouncer] section) will be used.
  
Test cases:
  - Tested the new helm chart on stage.
  - Specified the "numOfConnections" as 2 for the archival DB which defines the "max_db_connections" as 2.
  - Then tried starting 3 transactions for this DB in postgresql. Only 2 of them went through as expected.