### PR TITLE
Fix: Change charging component name to snappyflow-apm

### DIFF
--- a/charts/charging/Chart.yaml
+++ b/charts/charging/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charging
 description: A Helm chart for sfapm charging and usage tracking system
 type: application
-version: 0.4.23
+version: 0.4.24
 appVersion: v1
 
 

--- a/charts/charging/templates/celery-beat-deployment.yaml
+++ b/charts/charging/templates/celery-beat-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     role: beat
     app: charging
     role: celery
-    snappyflow/component: charging
+    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         role: beat
         app: charging
         role: celery
-        snappyflow/component: charging
+        snappyflow/component: {{ .Values.component }}
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/charging/templates/celery-worker-deployment.yaml
+++ b/charts/charging/templates/celery-worker-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: charging
     role: celery
     queue: default
-    snappyflow/component: charging
+    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -18,7 +18,7 @@ spec:
       app: charging
       role: celery
       queue: default
-      snappyflow/component: charging
+      snappyflow/component: {{ .Values.component }}
       {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
       {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
   template:
@@ -32,7 +32,7 @@ spec:
         app: charging
         role: celery
         queue: default
-        snappyflow/component: charging
+        snappyflow/component: {{ .Values.component }}
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/charging/templates/charging-deployment.yaml
+++ b/charts/charging/templates/charging-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     service: charging
     app: charging
     role: server
-    snappyflow/component: charging
+    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -20,7 +20,7 @@ spec:
       app: charging
       role: server
       service: charging
-      snappyflow/component: charging
+      snappyflow/component: {{ .Values.component }}
       {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
       {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
   template:
@@ -34,7 +34,7 @@ spec:
         app: charging
         role: server
         service: charging
-        snappyflow/component: charging
+        snappyflow/component: {{ .Values.component }}
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/charging/templates/service.yaml
+++ b/charts/charging/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     service: charging
     app: charging
     role: server
-    snappyflow/component: charging
+    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:

--- a/charts/charging/values.yaml
+++ b/charts/charging/values.yaml
@@ -7,6 +7,8 @@ replicaCount: 1
 
 schedulerName: sf-scheduler
 
+component: snappyflow-apm
+
 image:
   repository: snappyflowml/charging
   pullPolicy: Always


### PR DESCRIPTION
Jira ID:- https://maplelabs.atlassian.net/browse/SNP-4506
Description:- Can't get charging pod logs in UI, as component name is wrong.
Changes:- Snappyflow component name is changed to snappyflow-apm, as it is used to identify all snappyflow component and charging is under this component.
Verification:- All snappyflow components such as APM, vizbuilder, esmanager, command server component name is changed to snappyflow-apm, but charging is missed.