### PR TITLE
Fix: Removing component value from Matchcase in selector

### DIFF
--- a/charts/charging/Chart.yaml
+++ b/charts/charging/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: charging
 description: A Helm chart for sfapm charging and usage tracking system
 type: application
-version: 0.4.24
+version: 0.4.25
 appVersion: v1
 
 

--- a/charts/charging/templates/celery-beat-deployment.yaml
+++ b/charts/charging/templates/celery-beat-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     role: beat
     app: charging
     role: celery
-    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:

--- a/charts/charging/templates/celery-worker-deployment.yaml
+++ b/charts/charging/templates/celery-worker-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: charging
     role: celery
     queue: default
-    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -18,7 +17,6 @@ spec:
       app: charging
       role: celery
       queue: default
-      snappyflow/component: {{ .Values.component }}
       {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
       {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
   template:

--- a/charts/charging/templates/charging-deployment.yaml
+++ b/charts/charging/templates/charging-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     service: charging
     app: charging
     role: server
-    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -20,7 +19,6 @@ spec:
       app: charging
       role: server
       service: charging
-      snappyflow/component: {{ .Values.component }}
       {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
       {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
   template:

--- a/charts/charging/templates/service.yaml
+++ b/charts/charging/templates/service.yaml
@@ -7,7 +7,6 @@ metadata:
     service: charging
     app: charging
     role: server
-    snappyflow/component: {{ .Values.component }}
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:


### PR DESCRIPTION
Jira ID:- https://maplelabs.atlassian.net/browse/SNP-4506
Description:- Can't get charging pod logs in UI, as component name is wrong.
Changes:- Snappyflow component name is changed to snappyflow-apm, as it is used to identify all snappyflow component and charging is under this component.
Verification:- All snappyflow components such as APM, vizbuilder, esmanager, command server component name is changed to snappyflow-apm, but charging is missed.
Testing:-
Added helm render, created rendered template properly.
