### PR TITLE
config for path and logstream nginx-ingress

### DIFF
--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-ingress
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.6.31
+version: 3.6.32
 appVersion: 1.5.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -15,12 +15,6 @@ metadata:
 data:
   proxy-body-size: "13m"
   client-body-buffer-size: 10m
-  access-log-path: /var/log/nginx/access-custom.log
-  error-log-path: /var/log/nginx/error-custom.log
-  log-format-upstream: $http_x_forwarded_for $remote_user [$time_local] "$request"
-    $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_referer" rt=$request_time
-    uct=$upstream_connect_time uht=$upstream_header_time urt=$upstream_response_time
-    rs=$request_length
   allow-snippet-annotations: "{{ .Values.controller.allowSnippetAnnotations }}"
 {{- if .Values.controller.addHeaders }}
   add-headers: {{ .Release.Namespace }}/{{ include "ingress-nginx.fullname" . }}-custom-add-headers

--- a/charts/nginx-ingress/values.yaml
+++ b/charts/nginx-ingress/values.yaml
@@ -69,7 +69,13 @@ controller:
     https: 443
 
   # -- Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
-  config: {}
+  config: 
+    access-log-path: /var/log/nginx/access-custom.log
+    error-log-path: /var/log/nginx/error-custom.log
+    log-format-upstream: $http_x_forwarded_for $remote_user [$time_local] "$request"
+     $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_referer" rt=$request_time
+     uct=$upstream_connect_time uht=$upstream_header_time urt=$upstream_response_time
+     rs=$request_length
 
   # -- Annotations to be added to the controller config configuration configmap.
   configAnnotations: {}


### PR DESCRIPTION
issue: [SNP-6837]Configuration should be from helm values.yaml and not hardcoded
fix: added back the path to values.yaml