### PR TITLE
Fix: esmanager restrict internal api to localhost to protect from security issue

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.382
+version: 4.0.383
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/templates/ingress-rule.yaml
+++ b/charts/sfapm-python3/templates/ingress-rule.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace}}
   annotations:
     kubernetes.io/ingress.class: snappyflow-apm
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ~* "^/es-manager/internal" {
+          deny all;
+          return 403;
+        }
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:


### PR DESCRIPTION
JIRA: https://maplelabs.atlassian.net/browse/SNP-7310
Issue: esmanager Internal apis are exposed to internet without using token authentication, this may lead to security issue.

Analysis: Currently, we dont have any restriction for internal apis, this apis are used for internal service communication.

Fix: Now configured apache to restrict internal api to localhost only.

Testcase: Have configured ingress rule in stage portal, not able to access api from internet
![image](https://user-images.githubusercontent.com/36064146/231726822-4f4641f8-c2af-4574-8849-92898f341300.png)
