### PR TITLE
Fix: support to sf datapath without archival apis

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.392
+version: 4.0.393
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/templates/10-sfapm-configmap.yaml
+++ b/charts/sfapm-python3/templates/10-sfapm-configmap.yaml
@@ -25,6 +25,8 @@ data:
     REDIS_HOST: {{ .Release.Name  }}-redis
     REDIS_PORT: "6379"
 
+    ARCHIVER_ENABLED: {{ .Values.archiverEnabled }}
+
     VIZBUILDER_HOST: {{ include "sfapm.fullname" . }}-vizbuilder
     VIZBUILDER_PORT: "{{ .Values.vizbuilder.service.port }}"
 

--- a/charts/sfapm-python3/values.yaml
+++ b/charts/sfapm-python3/values.yaml
@@ -5,7 +5,7 @@
 # set to true to enable debug logs on
 # apm and vizbuilder
 enableDebug: false
-
+archiverEnabled: true
 nameOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []


### PR DESCRIPTION
Task: support to sf datapath without archival apis

Analysis: Enable/Disable archiver api call based on the helm enviormnet veraiable for cloudprofile and adding kafka controller