### PR TITLE
Fix: increasing nginx version support to kubernetes

### DIFF
--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx-ingress
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 3.6.33
+version: 3.6.34
 appVersion: 1.5.1
 home: https://github.com/kubernetes/ingress-nginx
 description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer

--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - ingress
   - nginx
 engine: gotpl
-kubeVersion: ">=1.20.0-0"
+kubeVersion: ">=1.19.0-0"
 annotations:
   # Use this annotation to indicate that this chart version is a pre-release.
   # https://artifacthub.io/docs/topics/annotations/helm/


### PR DESCRIPTION
Fix: increasing nginx version support to kubernetes

testcase: Verfied in Kube 19 version, able to deploy it successfully