### PR TITLE
Added support to disable archival in gateway chart

### DIFF
--- a/charts/sf-datapath-and-archival-gateway/Chart.yaml
+++ b/charts/sf-datapath-and-archival-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sf-datapath-and-archival-gateway
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "13.2.21"
 dependencies:
 - name: nginx

--- a/charts/sf-datapath-and-archival-gateway/templates/_helpers.tpl
+++ b/charts/sf-datapath-and-archival-gateway/templates/_helpers.tpl
@@ -22,6 +22,8 @@ datapath-and-archival-rest.conf: |-
   server {
     listen 0.0.0.0:8080;
 
+{{- if .Values.global.archivalEnabled }}
+
     location /ingest {
       proxy_pass http://{{ .Values.global.archivalReleaseName }}-ingest-controller/ingest;
     }
@@ -33,6 +35,8 @@ datapath-and-archival-rest.conf: |-
     location /query {
       proxy_pass http://{{ .Values.global.archivalReleaseName }}-query-controller/query;
     }
+
+{{- end }}
 
     location /sfkinterface {
       proxy_pass http://{{ .Values.global.datapathReleaseName }}-sfk-interface/sfkinterface;

--- a/charts/sf-datapath-and-archival-gateway/values.yaml
+++ b/charts/sf-datapath-and-archival-gateway/values.yaml
@@ -5,6 +5,8 @@ global:
     projectName: snappyflow-app
     appName: sf-data-path
 
+  archivalEnabled: true
+
   archivalReleaseName: archival
   datapathReleaseName: sf-datapath
 


### PR DESCRIPTION
Tests performed
    1. used a yaml file to disable archival and saw that proxy block didn't have archival specific URLs
        i.e., helm template .... -f test.yaml

Tested using helm template command