### PR TITLE
Fix: Increasing the sftrace celery worker concurrent process to 15

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.404
+version: 4.0.405
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/values.yaml
+++ b/charts/sfapm-python3/values.yaml
@@ -225,7 +225,7 @@ sfapm_celery:
         cpu: 10m
         memory: 100Mi
     replicaCount: 1
-    command: "celery -A snappyflow worker -l $LOG_LEVEL -Q sftrace -c10 $CELERY_OPTS"
+    command: "celery -A snappyflow worker -l $LOG_LEVEL -Q sftrace -c15 $CELERY_OPTS"
 
   provision:
     resources:


### PR DESCRIPTION
Fix: Increasing the sftrace celery worker to 15
Analysis: The sftrace tasks are not executing, piled up in redis. We are increasing concurrent process to 15