### PR TITLE
Fix: Add HPA for sftrace celery pods

### DIFF
--- a/charts/sf-saas-metrics/Chart.yaml
+++ b/charts/sf-saas-metrics/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sf-saas-metrics
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.16.0"
 dependencies:
 - name: prometheus

--- a/charts/sf-saas-metrics/values.yaml
+++ b/charts/sf-saas-metrics/values.yaml
@@ -391,6 +391,17 @@ prometheus-adapter:
           pod:
             resource: pod
       seriesQuery: '{__name__="num_executing_tasks"}'
+    - metricsQuery: <<.Series>>{pod=~".*celery-metrics-collector.*"}
+      name:
+        as: sftrace_queue_count
+        matches: ""
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      seriesQuery: '{__name__="sftrace_queue_count"}'
     - metricsQuery: <<.Series>>{pod=~".*dataset-raw-controller.*"}
       name:
         as: event_queue_handler_occupancy_percent

--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.400
+version: 4.0.401
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/charts/sf-apm/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-apm
 description: A Helm chart to deploy apm on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.1
+version: 4.0.2
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-apm/templates/00-serviceaccount-metric-collector.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/00-serviceaccount-metric-collector.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.global.sfapm_celery.sftrace.serviceAccountName }}
+  labels:
+    {{- include "sfapm.labels" . | nindent 4 }}
+{{- with .Values.global.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- range .Values.global.serviceAccount.imagePullSecrets }}
+  - {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/sfapm-python3/charts/sf-apm/templates/01-clusterrole.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/01-clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.global.sfapm_celery.sftrace.clusterRoleName }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]

--- a/charts/sfapm-python3/charts/sf-apm/templates/02-clusterrolebind.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/02-clusterrolebind.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.global.sfapm_celery.sftrace.clusterRoleBindingName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.global.sfapm_celery.sftrace.serviceAccountName }}
+roleRef:
+  kind: Role
+  name: {{ .Values.global.sfapm_celery.sftrace.clusterRoleName }}
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
-  replicas: {{ .Values.global.sfapm_celery.sftrace.replicaCount }}
+  replicas: {{ .Values.global.sfapm_celery.sftrace.autoscaling.minReplicas }}
   selector:
     matchLabels:
       {{- include "sfapm.selectorLabels" . | nindent 6 }}

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-metric-collector-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-metric-collector-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sfapm.fullname" . }}-celery-metrics-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "sfapm.fullname" . }}-celery-metrics-collector
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "2112"
+        prometheus.io/scrape: "true"
+      labels:
+        app: {{ include "sfapm.fullname" . }}-celery-metrics-collector
+    spec:
+      serviceAccountName: {{ .Values.global.sfapm_celery.sftrace.serviceAccountName }}
+      containers:
+        - name: sfapm-celery-metrics-collector
+          command: [/go/metrics]
+          image: snappyflowml/sftrace-celery-metrics-collector:latest
+          env:
+            - name: DEPLOYMENT_NAME
+              value: {{ include "sfapm.fullname" . }}-apm-celery-sftrace
+          envFrom:
+            - configMapRef:
+                name: {{ include "sfapm.fullname" . }}-apm
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+

--- a/charts/sfapm-python3/charts/sf-apm/templates/13-sftrace-celery-hpa.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/13-sftrace-celery-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.sfapm_celery.sftrace.clusterRoleBindingName }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "sfapm.fullname" . }}-apm-celery-sftrace
+  labels:
+    {{- include "sfapm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "sfapm.fullname" . }}-apm-celery-sftrace
+  minReplicas: {{ .Values.global.sfapm_celery.sftrace.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.global.sfapm_celery.sftrace.autoscaling.maxReplicas }}
+  metrics:
+    - type: Pods
+      pods:
+        metric:
+          name: sftrace_queue_count
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.global.sfapm_celery.sftrace.autoscaling.averageValue }}
+{{- end }}

--- a/charts/sfapm-python3/values.yaml
+++ b/charts/sfapm-python3/values.yaml
@@ -400,6 +400,16 @@ global:
       replicaCount: 1
       command: celery -A snappyflow worker -l $LOG_LEVEL -Q provision -c1 $CELERY_OPTS
     sftrace:
+      clusterRoleName: sftrace-metric-collector-role
+      clusterRoleBindingName: sftrace-metric-collector-role-binding
+      serviceAccountName: sftrace-metric-collector
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 5
+        scaleUpPeriod: 5
+        scaleDownPeriod: 120
+        averageValue: 900
       resources:
         limits:
           cpu: 1000m


### PR DESCRIPTION
Jira ID:- https://maplelabs.atlassian.net/browse/SNP-7684
Changes:- Adding autoscaling for sftrace celery pod, which uses queue count as threshold value.
Test case:-
Deployed new helm in stage environment,
Case Result:-

New components came up successfully.
Added new config in prometheus adapter.