### PR TITLE
Fix: Add HPA for sftrace celery pods

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.425
+version: 4.0.426
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/charts/sf-apm/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-apm
 description: A Helm chart to deploy apm on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.4
+version: 4.0.5
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
-  replicas: {{ .Values.global.sfapm_celery.sftrace.replicaCount }}
+  replicas: {{ .Values.global.sfapm_celery.sftrace.autoscaling.minReplicas }}
   selector:
     matchLabels:
       {{- include "sfapm.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Description: Autoscale and Min value of HPA is taken from same place, so that if min is high than deployment replica, it won't affect existing replicas.