### PR TITLE
Penetration testing SNP-7710

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.403
+version: 4.0.404
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/charts/sf-apm/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-apm
 description: A Helm chart to deploy apm on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.3
+version: 4.0.4
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-apm/templates/ingress-rule.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/ingress-rule.yaml
@@ -11,6 +11,10 @@ metadata:
           deny all;
           return 403;
         }
+      location ~* "^/latest" {
+        deny all;
+        return 403;
+      }
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:


### PR DESCRIPTION
**Description:**
The Cloud Metadata Attack attempts to abuse a misconfigured NGINX server in order to
access the instance metadata maintained by cloud service providers such as AWS, GCP
and Azure.
All of these providers provide metadata via an internal unroutable IP address
'169.254.169.254' - this can be exposed by incorrectly configured NGINX servers and
accessed by using this IP address in the Host header field.

**Solution:**
Blocked the /latest path in nginx configuration

**Testing:**
Verified in stage