### PR TITLE
Move role and rolebinding to kube-system namespace

### DIFF
--- a/charts/sf-cluster-autoscaler/Chart.yaml
+++ b/charts/sf-cluster-autoscaler/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sf-cluster-autoscaler
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.13
+version: 1.0.14
 appVersion: "1.0.0"

--- a/charts/sf-cluster-autoscaler/templates/serviceaccount.yaml
+++ b/charts/sf-cluster-autoscaler/templates/serviceaccount.yaml
@@ -70,7 +70,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: sfcluster-autoscaler
-  namespace: {{ .Values.namespace}}
+  namespace: kube-system
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: sfcluster-autoscaler
@@ -106,7 +106,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: sfcluster-autoscaler
-  namespace: {{ .Values.namespace}}
+  namespace: kube-system
   labels:
     k8s-addon: cluster-autoscaler.addons.k8s.io
     k8s-app: sfcluster-autoscaler


### PR DESCRIPTION
Issue: Following error is generated in autoscaler logs **Failed to retrieve status configmap for update: configmaps "cluster-autoscaler-status" is forbidden: User "system:serviceaccount:system:cluster-autoscaler" cannot get configmaps in the namespace "kube-system"**

RCA:  Cluster auto-scaler is working as expected this error does not affect any functionality. 
Below error is related a config map(auto created as a part of EKS) which we do not need in our auto-scaler deployment, but auto-scaler internal code is trying to watch it and since it is in different namespace(Kube-system) and our deployment is in default namespace hence auto-scaler was unable to read that config map. 

Solution: Move auto-scaler role and rolebinding to kube-system namespace. 

Refer:  https://github.com/kubernetes/autoscaler/issues/1620
https://github.com/kubernetes/autoscaler/pull/1648/files

