### PR TITLE
Issue: Added support for arm64 architecture

### DIFF
--- a/charts/sfagent/templates/cluster-agent-deployment.yaml
+++ b/charts/sfagent/templates/cluster-agent-deployment.yaml
@@ -24,7 +24,13 @@ spec:
     spec:
       containers:
       - name: cluster-agent
-        image: "{{ .Values.cluster_agent.image.repository }}:{{ .Values.cluster_agent.image.tag }}"
+        image: {{ if eq .Values.architecture "amd64" }}
+                     "{{ .Values.cluster_agent.image.amd64.repository }}:{{ .Values.cluster_agent.image.tag }}"
+                   {{ else if eq .Values.architecture "arm64" }}
+                     "{{ .Values.cluster_agent.image.arm64.repository }}:{{ .Values.cluster_agent.image.tag }}"
+                   {{ else }}
+                     "{{ .Values.cluster_agent.image.amd64.repository }}:{{ .Values.cluster_agent.image.tag }}"
+                   {{ end }}
         imagePullPolicy: {{ .Values.cluster_agent.image.pullPolicy }}
         command: ["/bin/sh","-c"]
         args: ["/app/kube-cluster"]
@@ -50,3 +56,4 @@ spec:
       nodeSelector:
 {{ toYaml .Values.cluster_agent.nodeSelector | indent 8 }}
 {{- end }}
+

--- a/charts/sfagent/templates/node-agent-daemonset.yaml
+++ b/charts/sfagent/templates/node-agent-daemonset.yaml
@@ -31,7 +31,13 @@ spec:
       hostPID: true
       containers:
       - name: node-agent
-        image: "{{ .Values.node_agent.image.repository }}:{{ .Values.node_agent.image.tag }}"
+        image: {{ if eq .Values.architecture "amd64" }}
+                     "{{ .Values.node_agent.image.amd64.repository }}:{{ .Values.node_agent.image.tag }}"
+                   {{ else if eq .Values.architecture "arm64" }}
+                     "{{ .Values.node_agent.image.arm64.repository }}:{{ .Values.node_agent.image.tag }}"
+                   {{ else }}
+                     "{{ .Values.node_agent.image.amd64.repository }}:{{ .Values.node_agent.image.tag }}"
+                   {{ end }}
         imagePullPolicy: {{ .Values.node_agent.image.pullPolicy }}
         command: ["/bin/sh","-c"]
         args: ["/app/kube-node -nodename $NODE_NAME -remote-socket-service-ip $SOCKET_SERVICE -basic-parsing {{ .Values.node_agent.basic_parsing }} -kubelet-for-metadata {{ .Values.node_agent.kubelet_for_metadata }} -mem-buf-limit-mb {{ .Values.node_agent.mem_buf_limit_mb }} -fluent-chunk-retry-limit {{ .Values.node_agent.fluent_chunk_retry_limit }} -debug={{ .Values.node_agent.debug }}"]
@@ -112,3 +118,4 @@ spec:
         - name: config
           configMap:
             name: {{ template "sf-apm-agents.fullname" . }}
+

--- a/charts/sfagent/values.yaml
+++ b/charts/sfagent/values.yaml
@@ -89,7 +89,10 @@ config:
 #  container for fluent-bit logs
 node_agent:
   image:
-    repository: snappyflowml/kube-node
+    amd64:
+      repository: snappyflowml/kube-node
+    arm64:
+      repository: snappyflowml/kube-node-arm
     tag: latest
     pullPolicy: Always
   resources:
@@ -186,13 +189,19 @@ forwardmetric:
       maxReplicas: 3
       targetCPUUtilizationPercentage: 80
 
+architecture: "amd64"
+
 # cluster level plugin Pod
 #   Container with cloud heartbeat + cluster document
 #   Container for kube events
 #   Container for application inventory
 cluster_agent:
   image:
-    repository: snappyflowml/kube-cluster
+    amd64:
+      repository: snappyflowml/kube-cluster
+      #tag: latest
+    arm64:
+      repository: snappyflowml/kube-cluster-arm
     tag: latest
     pullPolicy: Always
   # if enabled
@@ -212,5 +221,6 @@ cluster_agent:
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
+
 
 


### PR DESCRIPTION
Issue: Added support for arm64 architecture
Root cause: Enhancement
Changes made: 
•	Added arm based kube-node and kube-cluster images in values.yaml 
•	Added architecture value in values.yaml, contains default value to be “amd64” 
•	Made modifications in cluster-agent-deployment.yaml to branch based on architecture to pull associated docker image. 
•	Made modifications in node-agent-daemonset.yaml to branch based on architecture to pull associated docker image. 

Testcases: Tested on stage env and arm-based and amd-based instance, respective image associated to the specified architecture is being picked and the pods are installed and running successfully.
ARM-based: 

- Helm installation with arch field to contain arm64
![image](https://github.com/snappyflow/helm-charts/assets/110602101/90864ebf-513f-4e16-a31a-b5b02326a079)

- pods state
![image](https://github.com/snappyflow/helm-charts/assets/110602101/b1237f71-90c4-4204-8093-8aefbfe92a7e)

- Image picked from values.yaml 
![image](https://github.com/snappyflow/helm-charts/assets/110602101/cbea9a87-7f91-43e1-a23d-e6ab1dc03f71)

AMD-based:

- Helm installation with arch field to contain amd64
![image](https://github.com/snappyflow/helm-charts/assets/110602101/c475015b-0c19-412b-9a7a-0a0f852ee04f)

- pods state
![image](https://github.com/snappyflow/helm-charts/assets/110602101/2f3ae7f9-8477-4115-9f95-33665b7d3674)

- Image picked from values.yaml 
![image](https://github.com/snappyflow/helm-charts/assets/110602101/6000c4ec-f873-449b-9b57-48d79e980b47)


