### PR TITLE
Adding Correct Project name in values file

### DIFF
--- a/charts/kafka-cluster/charts/cp-kafka/Chart.yaml
+++ b/charts/kafka-cluster/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.1.6
+version: 0.1.7

--- a/charts/kafka-cluster/charts/cp-zookeeper/Chart.yaml
+++ b/charts/kafka-cluster/charts/cp-zookeeper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Zookeeper on Kubernetes
 name: cp-zookeeper
-version: 0.1.6
+version: 0.1.7

--- a/charts/kafka-cluster/values.yaml
+++ b/charts/kafka-cluster/values.yaml
@@ -1,6 +1,6 @@
 global:
   sfappname: sf-data-path
-  sfprojectname: snappyflow-app
+  sfprojectname: apmmanager-opensearch-azure
   sfappname_key: snappyflow/appname
   sfprojectname_key: snappyflow/projectname
 


### PR DESCRIPTION
For kafka-exporter, the metric data was going to snappyflow-app project.
We changed it to apmmanager-opensearch-azure