### PR TITLE
temporary fix for argocd issue argoproj/argo-cd/issues/5202

### DIFF
--- a/charts/sf-datapath/templates/_helpers.tpl
+++ b/charts/sf-datapath/templates/_helpers.tpl
@@ -36,9 +36,9 @@ To get api version for HPA
 */}}
 {{- define "autoscaling.apiVersion" -}}
    {{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
-      {{- print "autoscaling/v2" -}}
+      {{- print "autoscaling/v2beta1" -}}
    {{- else -}}
-     {{- print "autoscaling/v2beta2" -}}
+     {{- print "autoscaling/v2beta1" -}}
    {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Since k8 version of production is v1.22. 
I Update the Helm chart to use the API versions of autoscaling as v2beta1 which was supported by the environment for that specific version.

Testing:
Production version:
![AC2CB9B5-ACD2-44DE-A8C3-025D0D7EFF0F-version](https://github.com/snappyflow/helm-charts/assets/135819674/40f2a72d-663b-4ac7-9b1b-f31df4d60bea)

Autoscaling version:
![AC2CB9B5-ACD2-44DE-A8C3-025D0D7EFF0F-autoscaling](https://github.com/snappyflow/helm-charts/assets/135819674/72a94256-e698-4aca-bd50-1e46a7bc0030)
![68EAA87D-4B33-4622-9436-CF80826A78BD](https://github.com/snappyflow/helm-charts/assets/135819674/81947d63-261e-4df8-8a81-56f4c43dadfd)

If  still need the condition to check for autoscaling/v2 but want to use autoscaling/v2beta1 regardless, it is simpler to just always print autoscaling/v2beta1