### PR TITLE
adding component names for collecting logs in corresponding log type

### DIFF
--- a/charts/sfapm-python3/Chart.yaml
+++ b/charts/sfapm-python3/Chart.yaml
@@ -3,7 +3,7 @@ name: sfapm-python3
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.405
+version: 4.0.406
 appVersion: 4.0
 
 dependencies:

--- a/charts/sfapm-python3/charts/sf-apm/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-apm
 description: A Helm chart to deploy apm on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.6
+version: 4.0.7
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-beat-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-beat-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: beat
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: sfapm
         role: celery
         queue: beat
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-default-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-default-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: default
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: sfapm
         role: celery
         queue: default
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-notify-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-notify-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: notify
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: sfapm
         role: celery
         queue: notify
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-periodic-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-periodic-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: periodic
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: sfapm
         role: celery
         queue: periodic
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-provision-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-celery-provision-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: provision
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: sfapm
         role: celery
         queue: provision
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sfapm-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "sfapm.labels" . | nindent 4 }}
     app: sfapm
     role: server
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -25,7 +25,7 @@ spec:
         {{- include "sfapm.selectorLabels" . | nindent 8 }}
         app: sfapm
         role: server
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-apm/templates/12-sftrace-celery-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: sftrace
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: sfapm
         role: celery
         queue: sftrace
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-commands/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-commands/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-commands
 description: A Helm chart to deploy command server on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-commands/templates/62-commands-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-commands/templates/62-commands-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "sfapm.labels" . | nindent 4 }}
     app: commands
     role: server
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -25,7 +25,7 @@ spec:
         {{- include "sfapm.selectorLabels" . | nindent 8 }}
         app: commands
         role: server
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-commands/templates/63-commands-celery-beat-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-commands/templates/63-commands-celery-beat-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: commands
     role: celery
     queue: beat
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: commands
         role: celery
         queue: beat
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-commands/templates/64-commands-celery-default-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-commands/templates/64-commands-celery-default-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: commands
     role: celery
     queue: default
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: commands
         role: celery
         queue: default
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-pprof-server/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-pprof-server/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-pprof-server
 description: A Helm chart to deploy pprof-server on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-pprof-server/templates/50-pprof-server-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-pprof-server/templates/50-pprof-server-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "sfapm.labels" . | nindent 4 }}
     app: pprof
     role: pprof-server
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -26,7 +26,7 @@ spec:
         {{- include "sfapm.selectorLabels" . | nindent 8 }}
         app: pprof
         role: pprof-server
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-vizbuilder/Chart.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/Chart.yaml
@@ -3,5 +3,5 @@ name: sf-vizbuilder
 description: A Helm chart to deploy snappyflow on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.2
+version: 4.0.3
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-alert-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-alert-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: vizbuilder
     role: celery
     queue: alert
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: vizbuilder
         role: celery
         queue: alert
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-beat-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-beat-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sfapm
     role: celery
     queue: beat
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: vizbuilder
         role: celery
         queue: beat
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-logops-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-logops-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: vizbuilder
     role: celery
     queue: logops
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: vizbuilder
         role: celery
         queue: logops
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-provisiontemplate-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-provisiontemplate-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: vizbuilder
     role: celery
     queue: provisiontemplate
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: vizbuilder
         role: celery
         queue: provisiontemplate
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-signature-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-celery-signature-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: vizbuilder
     role: celery
     queue: signature
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -29,7 +29,7 @@ spec:
         app: vizbuilder
         role: celery
         queue: signature
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-deployment.yaml
+++ b/charts/sfapm-python3/charts/sf-vizbuilder/templates/22-vizbuilder-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "sfapm.labels" . | nindent 4 }}
     app: sfapm
     role: vizbuilder
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -25,7 +25,7 @@ spec:
         {{- include "sfapm.selectorLabels" . | nindent 8 }}
         app: sfapm
         role: vizbuilder
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:

--- a/charts/sfapm-python3/charts/sftrace/Chart.yaml
+++ b/charts/sfapm-python3/charts/sftrace/Chart.yaml
@@ -3,5 +3,5 @@ name: sftrace
 description: A Helm chart to deploy trace on Kubernetes
 home: https://www.snappyflow.io
 type: application
-version: 4.0.398
+version: 4.0.399
 appVersion: 4.0

--- a/charts/sfapm-python3/charts/sftrace/templates/42-sftrace-deployment.yaml
+++ b/charts/sfapm-python3/charts/sftrace/templates/42-sftrace-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "sfapm.labels" . | nindent 4 }}
     app: sftrace
     role: sftrace-server
-    # snappyflow/component: snappyflow-apm
+    snappyflow/component: snappyflow-apm
     {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfdatapath_appname }}
     {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
 spec:
@@ -26,7 +26,7 @@ spec:
         {{- include "sfapm.selectorLabels" . | nindent 8 }}
         app: sftrace
         role: sftrace-server
-        # snappyflow/component: snappyflow-apm
+        snappyflow/component: snappyflow-apm
         {{ default "snappyflow/appname" .Values.global.sfappname_key }}: {{ default .Release.Name .Values.global.sfappname }}
         {{ default "snappyflow/projectname" .Values.global.sfprojectname_key }}: {{ default .Release.Name .Values.global.sfprojectname }}
     spec:


### PR DESCRIPTION
It was removed in PR #642  because of the issue in parser.
Now parser issue is fixed so restoring the component names.